### PR TITLE
Fix homepage typo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
             .
           </li>
           <li className="tracking-[-.01em]">
-            Save and see your changes instantxxly.
+            Save and see your changes instantly.
           </li>
         </ol>
 


### PR DESCRIPTION
## Summary
- fix spelling of "instantly" on the homepage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe91ebfcc832fac3a30d711c582ef