### PR TITLE
Add Leaflet map page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Navigate to [http://localhost:3000/map](http://localhost:3000/map) for an interactive map view.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { MapContainer, TileLayer, Circle, useMap } from 'react-leaflet'
+import { MapContainer, TileLayer, Circle, useMap, useMapEvents } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import type { LatLngExpression } from 'leaflet'
 
@@ -21,9 +21,23 @@ function ResetButton({ onReset }: { onReset: () => void }) {
   )
 }
 
+function CircleMarker({ radiusKm, center, setCenter }: { radiusKm: number, center: LatLngExpression | null, setCenter: (center: LatLngExpression) => void }) {
+  const map = useMapEvents({
+    click() {
+      map.locate()
+    },
+    locationfound(e) {
+      setCenter(e.latlng)
+      map.flyTo(e.latlng, map.getZoom())
+    },
+  })
+
+  return center && <Circle center={center} radius={radiusKm * 1000} />
+}
+
 export default function MapPage() {
-  const [center, setCenter] = useState<LatLngExpression | null>(null)
   const [radiusKm, setRadiusKm] = useState(10)
+  const [center, setCenter] = useState<LatLngExpression | null>(null)
 
   return (
     <div className="flex flex-col items-center gap-4 p-4">
@@ -33,14 +47,12 @@ export default function MapPage() {
           zoom={2}
           className="h-full w-full"
           scrollWheelZoom
-          whenCreated={(map) => map.invalidateSize()}
-          onClick={(e) => setCenter(e.latlng)}
         >
           <TileLayer
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             attribution="&copy; OpenStreetMap contributors"
           />
-          {center && <Circle center={center} radius={radiusKm * 1000} />}
+          <CircleMarker radiusKm={radiusKm} center={center} setCenter={setCenter} />
         </MapContainer>
         <ResetButton onReset={() => setCenter(null)} />
       </div>

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useState } from 'react'
+import { MapContainer, TileLayer, Circle, useMap } from 'react-leaflet'
+import 'leaflet/dist/leaflet.css'
+import type { LatLngExpression } from 'leaflet'
+
+function ResetButton({ onReset }: { onReset: () => void }) {
+  const map = useMap()
+  const handleClick = () => {
+    map.setView([0, 0], 2)
+    onReset()
+  }
+  return (
+    <button
+      onClick={handleClick}
+      className="absolute top-2 right-2 z-[1000] bg-white/90 px-2 py-1 rounded"
+    >
+      Reset map
+    </button>
+  )
+}
+
+export default function MapPage() {
+  const [center, setCenter] = useState<LatLngExpression | null>(null)
+  const [radiusKm, setRadiusKm] = useState(10)
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <div className="relative w-full h-[500px]">
+        <MapContainer
+          center={[0, 0]}
+          zoom={2}
+          className="h-full w-full"
+          scrollWheelZoom
+          whenCreated={(map) => map.invalidateSize()}
+          onClick={(e) => setCenter(e.latlng)}
+        >
+          <TileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            attribution="&copy; OpenStreetMap contributors"
+          />
+          {center && <Circle center={center} radius={radiusKm * 1000} />}
+        </MapContainer>
+        <ResetButton onReset={() => setCenter(null)} />
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="range"
+          min="3"
+          max="100"
+          value={radiusKm}
+          onChange={(e) => setRadiusKm(Number(e.target.value))}
+        />
+        <span>{radiusKm} km</span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- document new /map route
- add interactive Leaflet map with radius slider and reset button

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687ff1a211f0832fa905a800ab7b2679