### PR TITLE
Prevent leaflet from running during SSR

### DIFF
--- a/src/app/map/MapPageClient.tsx
+++ b/src/app/map/MapPageClient.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const LeafletMap = dynamic(() => import('circlepop/components/LeafletMap'), {
+  ssr: false,
+})
+
+export default function MapPageClient() {
+  return <LeafletMap />
+}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,71 +1,7 @@
-'use client'
+import dynamic from 'next/dynamic'
 
-import { useState } from 'react'
-import { MapContainer, TileLayer, Circle, useMap, useMapEvents } from 'react-leaflet'
-import 'leaflet/dist/leaflet.css'
-import type { LatLngExpression } from 'leaflet'
-
-function ResetButton({ onReset }: { onReset: () => void }) {
-  const map = useMap()
-  const handleClick = () => {
-    map.setView([0, 0], 2)
-    onReset()
-  }
-  return (
-    <button
-      onClick={handleClick}
-      className="absolute top-2 right-2 z-[1000] bg-white/90 px-2 py-1 rounded"
-    >
-      Reset map
-    </button>
-  )
-}
-
-function CircleMarker({ radiusKm, center, setCenter }: { radiusKm: number, center: LatLngExpression | null, setCenter: (center: LatLngExpression) => void }) {
-  const map = useMapEvents({
-    click() {
-      map.locate()
-    },
-    locationfound(e) {
-      setCenter(e.latlng)
-      map.flyTo(e.latlng, map.getZoom())
-    },
-  })
-
-  return center && <Circle center={center} radius={radiusKm * 1000} />
-}
+const LeafletMap = dynamic(() => import('circlepop/components/LeafletMap'), { ssr: false })
 
 export default function MapPage() {
-  const [radiusKm, setRadiusKm] = useState(10)
-  const [center, setCenter] = useState<LatLngExpression | null>(null)
-
-  return (
-    <div className="flex flex-col items-center gap-4 p-4">
-      <div className="relative w-full h-[500px]">
-        <MapContainer
-          center={[0, 0]}
-          zoom={2}
-          className="h-full w-full"
-          scrollWheelZoom
-        >
-          <TileLayer
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-            attribution="&copy; OpenStreetMap contributors"
-          />
-          <CircleMarker radiusKm={radiusKm} center={center} setCenter={setCenter} />
-        </MapContainer>
-        <ResetButton onReset={() => setCenter(null)} />
-      </div>
-      <div className="flex items-center gap-2">
-        <input
-          type="range"
-          min="3"
-          max="100"
-          value={radiusKm}
-          onChange={(e) => setRadiusKm(Number(e.target.value))}
-        />
-        <span>{radiusKm} km</span>
-      </div>
-    </div>
-  )
+  return <LeafletMap />
 }

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,7 +1,5 @@
-import dynamic from 'next/dynamic'
-
-const LeafletMap = dynamic(() => import('circlepop/components/LeafletMap'), { ssr: false })
+import MapPageClient from './MapPageClient'
 
 export default function MapPage() {
-  return <LeafletMap />
+  return <MapPageClient />
 }

--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useState } from 'react'
+import { MapContainer, TileLayer, Circle, useMap, useMapEvents } from 'react-leaflet'
+import 'leaflet/dist/leaflet.css'
+import type { LatLngExpression } from 'leaflet'
+
+function ResetButton({ onReset }: { onReset: () => void }) {
+  const map = useMap()
+  const handleClick = () => {
+    map.setView([0, 0], 2)
+    onReset()
+  }
+  return (
+    <button
+      onClick={handleClick}
+      className="absolute top-2 right-2 z-[1000] bg-white/90 px-2 py-1 rounded"
+    >
+      Reset map
+    </button>
+  )
+}
+
+function CircleMarker({ radiusKm, center, setCenter }: { radiusKm: number, center: LatLngExpression | null, setCenter: (center: LatLngExpression) => void }) {
+  const map = useMapEvents({
+    click() {
+      map.locate()
+    },
+    locationfound(e) {
+      setCenter(e.latlng)
+      map.flyTo(e.latlng, map.getZoom())
+    },
+  })
+
+  return center && <Circle center={center} radius={radiusKm * 1000} />
+}
+
+export default function LeafletMap() {
+  const [radiusKm, setRadiusKm] = useState(10)
+  const [center, setCenter] = useState<LatLngExpression | null>(null)
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-4">
+      <div className="relative w-full h-[500px]">
+        <MapContainer
+          center={[0, 0]}
+          zoom={2}
+          className="h-full w-full"
+          scrollWheelZoom
+        >
+          <TileLayer
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            attribution="&copy; OpenStreetMap contributors"
+          />
+          <CircleMarker radiusKm={radiusKm} center={center} setCenter={setCenter} />
+        </MapContainer>
+        <ResetButton onReset={() => setCenter(null)} />
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="range"
+          min="3"
+          max="100"
+          value={radiusKm}
+          onChange={(e) => setRadiusKm(Number(e.target.value))}
+        />
+        <span>{radiusKm} km</span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- ensure interactive map only runs on client
- split map code into a `LeafletMap` component
- dynamically load it in the `/map` page with `ssr: false`

## Testing
- `pnpm run build` *(fails: Request was cancelled)*
- `pnpm run lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6880032962fc832fa5d7ce6d4babb984