### PR TITLE
Fix map click handling

### DIFF
--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -23,10 +23,7 @@ function ResetButton({ onReset }: { onReset: () => void }) {
 
 function CircleMarker({ radiusKm, center, setCenter }: { radiusKm: number, center: LatLngExpression | null, setCenter: (center: LatLngExpression) => void }) {
   const map = useMapEvents({
-    click() {
-      map.locate()
-    },
-    locationfound(e) {
+    click(e) {
       setCenter(e.latlng)
       map.flyTo(e.latlng, map.getZoom())
     },


### PR DESCRIPTION
## Summary
- set the circle center to the click location instead of using geolocation

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800a5f180c832f8ba1e25c79abab78