### PR TITLE
Implement population overlay with zoom and API integration

### DIFF
--- a/src/app/api/pop/route.ts
+++ b/src/app/api/pop/route.ts
@@ -4,24 +4,19 @@ import { NextRequest, NextResponse } from 'next/server'
 
 // just want to send a test response
 export async function GET(req: NextRequest) {
-  // const lat  = Number(req.nextUrl.searchParams.get('lat'))
-  // const lon  = Number(req.nextUrl.searchParams.get('lon'))
-  // const rKm  = Number(req.nextUrl.searchParams.get('r_km'))
+  const lat = Number(req.nextUrl.searchParams.get('lat'))
+  const lon = Number(req.nextUrl.searchParams.get('lon'))
+  const rKm = Number(req.nextUrl.searchParams.get('r_km'))
 
-  // if (!lat || !lon || rKm < 3 || rKm > 50) {
-  //   return NextResponse.json({ error: 'invalid params' }, { status: 400 })
-  // }
+  if (
+    Number.isNaN(lat) ||
+    Number.isNaN(lon) ||
+    Number.isNaN(rKm)
+  ) {
+    return NextResponse.json({ error: 'invalid params' }, { status: 400 })
+  }
 
-  // const { rows } = await sql`
-  //   SELECT SUM(pop) AS p
-  //     FROM grid25
-  //    WHERE ST_DWithin(
-  //          geog,
-  //          ST_SetSRID(ST_MakePoint(${lon}, ${lat}), 4326)::geography,
-  //          ${rKm * 1000}
-  //        );
-  // `
-  // return NextResponse.json({ population: rows[0]?.p ?? 0 })
-  return NextResponse.json({ population: 1000000 })
+  // TODO: replace this with real population calculation
+  return NextResponse.json({ population: 1000 })
 }
 


### PR DESCRIPTION
## Summary
- zoom to frame the circle when a map click occurs
- hit `/api/pop` when clicking on the map
- show the returned population over the map
- stub API now validates query params and returns a hardcoded value

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800d3d4028832f8896b306b9cf25ed