### PR TITLE
Adjust UI colors for map overlays

### DIFF
--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -15,7 +15,7 @@ function ResetButton({ onReset }: { onReset: () => void }) {
   return (
     <button
       onClick={handleClick}
-      className="absolute top-2 right-2 z-[1000] bg-white/90 px-2 py-1 rounded"
+      className="absolute top-2 right-2 z-[1000] bg-foreground/90 text-background font-medium px-2 py-1 rounded shadow hover:bg-foreground"
     >
       Reset map
     </button>
@@ -76,7 +76,7 @@ export default function LeafletMap() {
           <ResetButton onReset={() => { setCenter(null); setPopulation(null) }} />
         </MapContainer>
         {population !== null && (
-          <div className="absolute top-2 left-2 z-[1000] bg-white/90 px-2 py-1 rounded">
+          <div className="absolute top-2 left-2 z-[1000] bg-foreground/90 text-background px-2 py-1 rounded shadow">
             Population in the circle: {population}
           </div>
         )}


### PR DESCRIPTION
## Summary
- refine "Reset map" button styling so it doesn't appear disabled
- update population overlay to match theme colors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802ad2fb34832f8d29f74b990e2c1c