### PR TITLE
Update map layout and controls

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,9 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.content {
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <PopLoader />
-        {children}
+        <div className="content">{children}</div>
       </body>
     </html>
   );

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,5 +1,10 @@
 import MapPageClient from './MapPageClient'
 
 export default function MapPage() {
-  return <MapPageClient />
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <h1 className="text-2xl font-bold text-center mt-4">CirclePop🎈📌</h1>
+      <MapPageClient />
+    </div>
+  )
 }

--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -15,7 +15,7 @@ function ResetButton({ onReset }: { onReset: () => void }) {
   return (
     <button
       onClick={handleClick}
-      className="absolute top-2 right-2 z-[1000] bg-foreground/90 text-background font-medium px-2 py-1 rounded shadow hover:bg-foreground"
+      className="absolute bottom-12 right-2 z-[1000] bg-foreground/90 text-background font-medium px-2 py-1 rounded shadow hover:bg-foreground"
     >
       Reset map
     </button>
@@ -78,7 +78,7 @@ export default function LeafletMap() {
           <ResetButton onReset={() => { setCenter(null); setPopulation(null) }} />
         </MapContainer>
         {population !== null && (
-          <div className="absolute top-2 left-2 z-[1000] bg-foreground/90 text-background px-2 py-1 rounded shadow">
+          <div className="absolute bottom-12 left-2 z-[1000] bg-foreground/90 text-background px-2 py-1 rounded shadow">
             Population in the circle: {population}
           </div>
         )}


### PR DESCRIPTION
## Summary
- center all pages in a `.content` container
- show a header on the map page
- reposition the reset button and population display

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880734d9848832f8db829fafcae12ee